### PR TITLE
add Siglent SDS1000X-E and SDS2000X-E to the supported models table

### DIFF
--- a/section-drivers.tex
+++ b/section-drivers.tex
@@ -387,6 +387,10 @@ An old Siglent driver with significant bitrot is available in the git archive if
 \thickhline
 \textbf{Device Family} & \textbf{Driver} & \textbf{Transport} & \textbf{Notes} \\
 \thickhline
+SDS1000X-E series & siglent & lan & Initialises, triggers and downloads waveforms. More testing needed \\
+\thickhline
+SDS2000X-E series & siglent & lan & Initialises, triggers and downloads waveforms. More testing needed \\
+\thickhline
 SDS2000X+ series & siglent & lan & Basic functionality complete. Digital channels and advanced triggering remain to be added. \\
 \thickhline
 SDS5000X series & siglent & lan & Initialises, triggers and downloads waveforms. More testing needed \\
@@ -395,7 +399,7 @@ SDS6000X series & siglent & lan & Untested. Not available in Western Markets. \\
 \thickhline
 \end{tabularx}
 
-No other Siglent scopes are supported at the moment although work is progressing on the SDS1000X-E series.
+No other Siglent scopes are supported at the moment.
 
 The only exception to this is the SDS3000X series which is expected to work using the LeCroy driver over vicp interface
 as if it were a WaveSurfer 3000. User feedback appreciated.\\


### PR DESCRIPTION
I changed this in the section about the Siglent scopes:
![image](https://user-images.githubusercontent.com/148607/168703253-1a416088-04ae-447f-996c-f11a1d2dc7ab.png)
