### PR TITLE
Initial power supply docs

### DIFF
--- a/glscopeclient-manual.tex
+++ b/glscopeclient-manual.tex
@@ -89,6 +89,7 @@
 \include{section-gettingstarted}
 \include{section-transports}
 \include{section-scope-drivers}
+\include{section-powersupply-drivers}
 \include{section-mainwindow}
 \FloatBarrier
 \include{section-waveformgroups}

--- a/glscopeclient-manual.tex
+++ b/glscopeclient-manual.tex
@@ -88,7 +88,7 @@
 \include{section-legal}
 \include{section-gettingstarted}
 \include{section-transports}
-\include{section-drivers}
+\include{section-scope-drivers}
 \include{section-mainwindow}
 \FloatBarrier
 \include{section-waveformgroups}

--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -61,7 +61,7 @@ a reasonable minimum, with 32 or more encouraged for deep history.
 \section{Instrument Support}
 
 glscopeclient uses the libscopehal library to communicate with oscilloscopes, so any libscopehal-compatible hardware
-should work with glscopeclient. See the \hyperref[sec:drivers]{Oscilloscope Drivers} section for more details on which
+should work with glscopeclient. See the \hyperref[sec:scope-drivers]{Oscilloscope Drivers} section for more details on which
 hardware is supported and how to configure specific drivers.
 
 \section{Compilation}

--- a/section-powersupply-drivers.tex
+++ b/section-powersupply-drivers.tex
@@ -1,0 +1,29 @@
+\chapter{Power Supply Drivers}
+\label{sec:powersupply-drivers}
+
+\section{GW Instek}
+
+\begin{tabularx}{16cm}{lllX}
+\thickhline
+\textbf{Device Family} & \textbf{Driver} & \textbf{Transport} & \textbf{Notes} \\
+\thickhline
+GPD-X303S series & gwinstek_gpdx303s & uart & 9600 Baud default. Tested with GPD-3303S. No support for tracking modes yet.\\
+\thickhline
+\end{tabularx}
+
+\subsection{gwinstek_gpdx303s}
+
+Supported models should include GPD-2303S, GPD-3303S, GPD-4303S, and GPD-3303D.
+
+\section{Rohde & Schwarz}
+
+\begin{tabularx}{16cm}{lllX}
+\thickhline
+\textbf{Device Family} & \textbf{Driver} & \textbf{Transport} & \textbf{Notes} \\
+\thickhline
+HMC804x series & rs_hmc804x & uart, usbtmc, lan & No support for tracking modes yet.\\
+\thickhline
+\end{tabularx}
+
+\subsection{rs_hmc804x}
+

--- a/section-scope-drivers.tex
+++ b/section-scope-drivers.tex
@@ -1,5 +1,5 @@
 \chapter{Oscilloscope Drivers}
-\label{sec:drivers}
+\label{sec:scope-drivers}
 
 \section{Agilent}
 


### PR DESCRIPTION
Pretty barebones, but this adds an extra section to the pdf manual documenting the drivers currently extant for power supplies and which models are supported.