### PR TITLE
Add for windows install step for WiX Toolset v3.11 required to build Windows x64 MSI

### DIFF
--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -214,6 +214,10 @@ This will avoid lots of hard to diagnose problems later on in the build.\\
 All following steps are to be done in a MinGW64 shell (\textbf{not} in a MSYS, MINGW32, CLANG64, CLANG32 or UCRT64 shell,
 which also get installed by the MSYS2 installer).
 
+\item Install WiX Toolset v3.11 (required to build the Windows x64 MSI)
+You shall download and install WiX Toolset v3.11 in C:\Program Files (x86)\WiX Toolset v3.11
+https://wixtoolset.org/docs/wix3/
+
 \item Install git and the toolchain:
 
 \begin{lstlisting}[language=sh, numbers=none]


### PR DESCRIPTION
Add for windows install step for WiX Toolset v3.11 required to build the Windows x64 MSI
See issue https://github.com/glscopeclient/scopehal-apps/issues/574