### PR TITLE
Updated Vulkan references to version 1.3.250.1

### DIFF
--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -113,10 +113,10 @@ sudo make install
 cd ~
 mkdir vulkan
 cd vulkan
-wget https://sdk.lunarg.com/sdk/download/1.3.250.0/linux/vulkansdk-linux-x86_64-1.3.250.0.tar.gz
-tar xf vulkansdk-linux-x86_64-1.3.250.0.tar.gz
-rm -f vulkansdk-linux-x86_64-1.3.250.0.tar.gz
-export VULKAN_SDK=~/vulkan/1.3.250.0/x86_64
+wget https://sdk.lunarg.com/sdk/download/1.3.250.1/linux/vulkansdk-linux-x86_64-1.3.250.1.tar.gz
+tar xf vulkansdk-linux-x86_64-1.3.250.1.tar.gz
+rm -f vulkansdk-linux-x86_64-1.3.250.1.tar.gz
+export VULKAN_SDK=~/vulkan/1.3.250.1/x86_64
 sudo cp -r $VULKAN_SDK/include/vulkan/ /usr/local/include/
 sudo cp -P $VULKAN_SDK/lib/libvulkan.so* /usr/local/lib/
 sudo cp $VULKAN_SDK/lib/libVkLayer_*.so /usr/local/lib/
@@ -128,7 +128,7 @@ sudo ldconfig
 \item Build scopehal and scopehal-apps:
 
 \begin{lstlisting}[language=sh, numbers=none]
-export VULKAN_SDK=~/vulkan/1.3.250.0/x86_64
+export VULKAN_SDK=~/vulkan/1.3.250.1/x86_64
 export PATH=$VULKAN_SDK/bin:$PATH
 export LD_LIBRARY_PATH=$VULKAN_SDK/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 export VK_LAYER_PATH=$VULKAN_SDK/etc/vulkan/explicit_layer.d
@@ -224,15 +224,15 @@ https://wixtoolset.org/docs/wix3/
 pacman -S git wget mingw-w64-x86_64-cmake mingw-w64-x86_64-toolchain
 \end{lstlisting}
 
-\item Build glslang tags/sdk-1.3.250.0:
+\item Build glslang tags/sdk-1.3.250.1:
 
 Launch MSYS2 or MINGW64 as Administrator only for this step (it is mandatory to do the install in default path C:\\VulkanSDK ...)
 \begin{lstlisting}[language=sh, numbers=none]
-# Windows mingw64 glslang build (as it is not fully integrated in VulkanSDK-1.3.250.0 for Windows and built with Visual Studio 2019)
+# Windows mingw64 glslang build (as it is not fully integrated in VulkanSDK-1.3.250.1 for Windows and built with Visual Studio 2019)
 cd ~
 git clone https://github.com/KhronosGroup/glslang.git
 cd glslang
-git checkout tags/sdk-1.3.250.0
+git checkout tags/sdk-1.3.250.1
 git clone https://github.com/google/googletest.git External/googletest
 cd External/googletest
 git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
@@ -252,9 +252,9 @@ cmake --build . --config Release --target install
 Launch MSYS2 or MINGW64 as Administrator only for this step (it is mandatory to do the install in default path C:\\VulkanSDK ...)
 \begin{lstlisting}[language=sh, numbers=none]
 cd ~
-wget https://sdk.lunarg.com/sdk/download/1.3.250.0/windows/VulkanSDK-1.3.250.0-Installer.exe
-./VulkanSDK-1.3.250.0-Installer.exe --accept-licenses --default-answer --confirm-command install
-rm -f VulkanSDK-1.3.250.0-Installer.exe
+wget https://sdk.lunarg.com/sdk/download/1.3.250.1/windows/VulkanSDK-1.3.250.1-Installer.exe
+./VulkanSDK-1.3.250.1-Installer.exe --accept-licenses --default-answer --confirm-command install
+rm -f VulkanSDK-1.3.250.1-Installer.exe
 \end{lstlisting}
 
 \item Check out the code
@@ -268,7 +268,7 @@ git clone --recursive https://github.com/glscopeclient/scopehal-apps
 
 \begin{lstlisting}[language=sh, numbers=none]
 cd ~/scopehal-apps/msys2
-export VK_SDK_PATH=/c/VulkanSDK/1.3.250.0
+export VK_SDK_PATH=/c/VulkanSDK/1.3.250.1
 export PATH=$VK_SDK_PATH/Bin:$PATH
 export VULKAN_SDK=$VK_SDK_PATH
 export GLSLANG_BUILD_PATH=~/glslang/build/install


### PR DESCRIPTION
Updated Vulkan references to latest, previous links return 404s.