### PR TITLE
Fedora dependency setup update

### DIFF
--- a/glscopeclient-manual.tex
+++ b/glscopeclient-manual.tex
@@ -35,6 +35,7 @@
 \lstset{breakatwhitespace=false}
 \lstset{basicstyle=\small\ttfamily}
 \lstset{columns=fullflexible}
+\lstset{prebreak=\textbackslash}
 
 % standard colors for protocol decodes
 \usepackage{xcolor}

--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -83,12 +83,13 @@ sudo apt install build-essential cmake pkg-config libglm-dev \
 	catch2 libvulkan-dev glslang-dev libglfw3-dev
 \end{lstlisting}
 
-On Fedora(this section is out of date):
+On Fedora:
 
 \begin{lstlisting}[language=sh, numbers=none]
+sudo dnf group install "C Development Tools and Libraries"
 sudo dnf install gtkmm30-devel cmake pkg-config glm-devel \
 	texlive libyaml-devel yaml-cpp-devel glew-devel \
-	catch-devel vulkan-devel
+	catch-devel vulkan-devel glfw-devel
 \end{lstlisting}
 
 If you are using an older stable release (such as Debian Buster), you may need to install catch2 from source

--- a/section-ng-gettingstarted.tex
+++ b/section-ng-gettingstarted.tex
@@ -85,12 +85,13 @@ sudo apt install build-essential cmake pkg-config libglm-dev \
 	catch2 libvulkan-dev glslang-dev libglfw3-dev
 \end{lstlisting}
 
-On Fedora(this section is out of date):
+On Fedora:
 
 \begin{lstlisting}[language=sh, numbers=none]
+sudo dnf group install "C Development Tools and Libraries"
 sudo dnf install gtkmm30-devel cmake pkg-config glm-devel \
 	texlive libyaml-devel yaml-cpp-devel glew-devel \
-	catch-devel vulkan-devel
+	catch-devel vulkan-devel glfw-devel
 \end{lstlisting}
 
 If you are using an older stable release (such as Debian Buster), you may need to install catch2 from source


### PR DESCRIPTION
Adds glfw-devel and C development tools. Tested build and execution on Fedora 38.