### PR TITLE
Add backslash/multiline breaks to glscopeclient doc

### DIFF
--- a/glscopeclient-manual.tex
+++ b/glscopeclient-manual.tex
@@ -35,6 +35,7 @@
 \lstset{breakatwhitespace=false}
 \lstset{basicstyle=\small\ttfamily}
 \lstset{columns=fullflexible}
+\lstset{prebreak=\textbackslash}
 
 % standard colors for protocol decodes
 \usepackage{xcolor}


### PR DESCRIPTION
This was missing in glscopeclient doc.

For reference, this automatically inserts a backslash whenever listings package breaks text to multiple lines.